### PR TITLE
Make community stats dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,9 @@ This repository holds our public website ([moov.io](https://moov.io)) discussing
 
 - Please refer to [Hugo's documentation](https://gohugo.io/content-management/) for details on modifying content.
 
-## Updating Hugo Theme
+## Updating Community Stats
 
-Inside the theme directory run `git pull`. Then `make build && make run` to verify the site loads as expected and then open a pull request.
-
-```
-$ cd themes/hugo-fresh/
-
-$ git pull origin master
-From https://github.com/StefMa/hugo-fresh
- * branch            master     -> FETCH_HEAD
-Updating 1896157..5ebe24e
-Fast-forward
-```
+To update the counts for Slack users, Github Stars and Twitter, open `data/stats.toml` and change the lablled values.
 
 ## Getting Help
 

--- a/data/stats.toml
+++ b/data/stats.toml
@@ -1,0 +1,3 @@
+slackUsers = 419
+githubStars = 367
+twitterFollowers = 542

--- a/themes/moov/layouts/index.html
+++ b/themes/moov/layouts/index.html
@@ -274,15 +274,15 @@
     <div class="stats">
       <ul>
         <li>
-          <span class="number">419</span>
+          <span class="number">{{.Site.Data.stats.slackUsers}}</span>
           <span class="title">SLACK <br> USERS</span>
         </li>
         <li>
-          <span class="number">367</span>
+          <span class="number">{{.Site.Data.stats.githubStars}}</span>
           <span class="title">GITHUB <br> STARS</span>
         </li>
         <li>
-          <span class="number">540</span>
+          <span class="number">{{.Site.Data.stats.twitterFollowers}}</span>
           <span class="title">TWITTER <br> FOLLOWERS</span>
         </li>
       </ul>


### PR DESCRIPTION
Fixes #61 

Updating community stats on the site should be easier. Now it is.