### PR TITLE
check for feature image in post templates

### DIFF
--- a/themes/moov/layouts/blog/single.html
+++ b/themes/moov/layouts/blog/single.html
@@ -3,11 +3,13 @@
     <article class="contain" itemscope itemtype="https://schema.org/BlogPosting">
       <div class="post-image">
         {{ $original := .Page.Resources.GetMatch "feature" }}
-        {{ .Scratch.Set "image1x" ($original.Resize "1520x") }}
-        {{ .Scratch.Set "image2x" ($original.Resize "3040x") }}
-        {{ $image1x := .Scratch.Get "image1x" }}
-        {{ $image2x := .Scratch.Get "image2x" }}
-        <img src="{{ $image1x.RelPermalink }}" srcset="{{ $image2x.RelPermalink }} 2x" class="post-image">
+        {{ if $original }}
+          {{ .Scratch.Set "image1x" ($original.Resize "1520x") }}
+          {{ .Scratch.Set "image2x" ($original.Resize "3040x") }}
+          {{ $image1x := .Scratch.Get "image1x" }}
+          {{ $image2x := .Scratch.Get "image2x" }}
+          <img src="{{ $image1x.RelPermalink }}" srcset="{{ $image2x.RelPermalink }} 2x" class="post-image">
+        {{ end }}
       </div>
       <h1 class="post-title serif" itemprop="headline">{{ .Title }}</h1>
       <div class="sidebar">
@@ -58,14 +60,16 @@
     <section class="further-reading">
       <div class="contain">
         <a href="{{.RelPermalink}}">
-          <figure>
-            {{ $original := .Page.Resources.GetMatch "feature" }}
-            {{ .Scratch.Set "image1x" ($original.Fill "470x310 Center") }}
-            {{ .Scratch.Set "image2x" ($original.Fill "940x620 Center") }}
-            {{ $image1x := .Scratch.Get "image1x" }}
-            {{ $image2x := .Scratch.Get "image2x" }}
-            <img src="{{ $image1x.RelPermalink }}" srcset="{{ $image2x.RelPermalink }} 2x" width="{{ $image1x.Width }}" height="{{ $image1x.Height }}" alt="" loading="lazy">
-          </figure>
+          {{ if $original }}
+            <figure>
+              {{ $original := .Page.Resources.GetMatch "feature" }}
+              {{ .Scratch.Set "image1x" ($original.Fill "470x310 Center") }}
+              {{ .Scratch.Set "image2x" ($original.Fill "940x620 Center") }}
+              {{ $image1x := .Scratch.Get "image1x" }}
+              {{ $image2x := .Scratch.Get "image2x" }}
+              <img src="{{ $image1x.RelPermalink }}" srcset="{{ $image2x.RelPermalink }} 2x" width="{{ $image1x.Width }}" height="{{ $image1x.Height }}" alt="" loading="lazy">
+            </figure>
+          {{ end }}
           <div>
             <div class="label">Next up</div>
             <div class="further-reading-title">{{.Title}}</div>

--- a/themes/moov/layouts/partials/article-list-item.html
+++ b/themes/moov/layouts/partials/article-list-item.html
@@ -1,11 +1,13 @@
 <article class="article-list-item fadeup">
   <a href="{{ .RelPermalink }}">
     {{ $original := .Page.Resources.GetMatch "feature" }}
-    {{ .Scratch.Set "image1x" ($original.Fill "470x310 Center") }}
-    {{ .Scratch.Set "image2x" ($original.Fill "940x620 Center") }}
-    {{ $image1x := .Scratch.Get "image1x" }}
-    {{ $image2x := .Scratch.Get "image2x" }}
-    <img src="{{ $image1x.RelPermalink }}" srcset="{{ $image2x.RelPermalink }} 2x" class="article-list-item-image" width="{{ $image1x.Width }}" height="{{ $image1x.Height }}" alt="" loading="lazy">
+    {{ if $original }}
+      {{ .Scratch.Set "image1x" ($original.Fill "470x310 Center") }}
+      {{ .Scratch.Set "image2x" ($original.Fill "940x620 Center") }}
+      {{ $image1x := .Scratch.Get "image1x" }}
+      {{ $image2x := .Scratch.Get "image2x" }}
+      <img src="{{ $image1x.RelPermalink }}" srcset="{{ $image2x.RelPermalink }} 2x" class="article-list-item-image" width="{{ $image1x.Width }}" height="{{ $image1x.Height }}" alt="" loading="lazy">
+    {{ end }}
   </a>
   <p class="category">{{ range .Params.categories }}<a href="/blog/categories/{{ . | urlize}}">{{ . }}</a>{{ end }} &bull; {{ .ReadingTime }} minute read
   </p>

--- a/themes/moov/layouts/partials/featured-article.html
+++ b/themes/moov/layouts/partials/featured-article.html
@@ -1,12 +1,14 @@
 <article class="featured-article">
-  <a href="{{ .RelPermalink }}" class="featured-article-image">
-    {{ $original := .Page.Resources.GetMatch "feature" }}
-    {{ .Scratch.Set "image1x" ($original.Fill "900x400 Center") }}
-    {{ .Scratch.Set "image2x" ($original.Fill "1800x800 Center") }}
-    {{ $image1x := .Scratch.Get "image1x" }}
-    {{ $image2x := .Scratch.Get "image2x" }}
-    <img src="{{ $image1x.RelPermalink }}" srcset="{{ $image2x.RelPermalink }} 2x" class="featured-image" width="{{ $image1x.Width }}" height="{{ $image1x.Height }}" alt="" loading="eager">
-  </a>
+  {{ $original := .Page.Resources.GetMatch "feature" }}
+  {{ if $original }}
+    <a href="{{ .RelPermalink }}" class="featured-article-image">
+      {{ .Scratch.Set "image1x" ($original.Fill "900x400 Center") }}
+      {{ .Scratch.Set "image2x" ($original.Fill "1800x800 Center") }}
+      {{ $image1x := .Scratch.Get "image1x" }}
+      {{ $image2x := .Scratch.Get "image2x" }}
+      <img src="{{ $image1x.RelPermalink }}" srcset="{{ $image2x.RelPermalink }} 2x" class="featured-image" width="{{ $image1x.Width }}" height="{{ $image1x.Height }}" alt="" loading="eager">
+    </a>
+  {{ end }}
   <div class="featured-article-meta">
     <p class="category">{{ range .Params.categories }}<a href="/blog/categories/{{ . | urlize}}">{{ . }}</a>{{ end }} &bull; {{ .ReadingTime }} minute read
     </p>


### PR DESCRIPTION
Fix for issue #76 

Updated templates to check for existence of a feature image in post templates before processing & rendering.

Posts with no image referenced will not show a featured image, but will still render:

![moov-post-ex](https://user-images.githubusercontent.com/4248884/91724731-5a730b00-eb63-11ea-8645-2afd3c967727.png)

![moov-article-ex](https://user-images.githubusercontent.com/4248884/91724755-65c63680-eb63-11ea-9101-d0ad6e018e60.png)